### PR TITLE
Exclude breaking updates from Renovate groups

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -10,6 +10,7 @@
       description: "Group npm package patch/minor updates into one PR.",
       matchManagers: ["npm"],
       matchUpdateTypes: ["patch", "minor"],
+      matchJsonata: ["isBreaking != true"],
       groupName: "npm package patch/minor updates",
       groupSlug: "npm-package-patch-minor",
     },


### PR DESCRIPTION
## Summary
- Exclude Renovate updates marked `isBreaking` from patch/minor dependency groups.
- Keep existing per-ecosystem grouping, while letting potentially breaking 0.x and similar updates open separately.

## Validation
- `npm exec --yes --package renovate renovate-config-validator`