### PR TITLE
Enable Renovate lock file maintenance

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,6 +5,10 @@
 
   minimumReleaseAge: "3 days",
 
+  lockFileMaintenance: {
+    enabled: true,
+  },
+
   packageRules: [
     {
       description: "Group npm package patch/minor updates into one PR.",


### PR DESCRIPTION
## Summary

- enable Renovate's top-level `lockFileMaintenance` configuration
- allow Renovate to refresh `pnpm-lock.yaml` on its weekly lock-file maintenance schedule

## Why

Weekly lock-file refreshes pick up newer compatible transitive dependency resolutions even when manifest version ranges do not change. This helps keep the resolved dependency graph current and avoids large, infrequent lockfile jumps.

## Impact

This changes dependency automation only. Renovate can now propose periodic lockfile-only maintenance updates; application runtime behavior and existing Renovate package rules are unchanged.

## Checks

- parsed `renovate.json5` as a JavaScript-compatible JSON5 object with dependency-free Node.js
- asserted `lockFileMaintenance.enabled === true`
- ran `git diff --check` before commit
- inspected the staged and committed diff to confirm only `renovate.json5` changed